### PR TITLE
Add CMake support for nrr_enumerate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
+target_compile_features(
+    ${PROJECT_NAME} INTERFACE cxx_std_17)
+
 install(
     TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}-config)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.15)
+project(nrr_enumerate LANGUAGES CXX)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+include(GNUInstallDirs)
+
+target_include_directories(
+    ${PROJECT_NAME} INTERFACE
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-config)
+
+install(
+    EXPORT ${PROJECT_NAME}-config
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/${PROJECT_NAME}/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})

--- a/include/nrr_enumerate/nrr_enumerate.h
+++ b/include/nrr_enumerate/nrr_enumerate.h
@@ -68,6 +68,6 @@ namespace nrr
         };
         return iterable_wrapper{ std::forward<T>(iterable) };
     }
-}
+} // namespace nrr
 
 #undef NRR_REQUIRES


### PR DESCRIPTION
Hi there,

This PR adds a `CMakeLists.txt` file to support installing the library (if you so wish) and also using it with `FetchContent`.

I also added a closing namespace block and I would also propose updating the extension to `.hpp` as opposed to `.h` to distinguish it from a pure C header (as it has lots of shiny new C++ template magic).

Example usage:

```cmake
# after installing
...
find_package(nrr_enumerate CONFIG REQUIRED)
...
target_link_libraries(${PROJECT_NAME} PRIVATE nrr_enumerate::nrr_enumerate)

# or

include(FetchContent)
FetchContent_Declare(
    nrr_enumerate GIT_REPOSITORY https://github.com/Reedbeta/nrr_enumerate.git)
FetchContent_MakeAvailable(nrr_enumerate)
...
target_link_libraries(${PROJECT_NAME} PRIVATE nrr_enumerate)

```

Thanks!


Tom